### PR TITLE
Use npm svg-crowbar instead of direct NYT link

### DIFF
--- a/ms/index.html
+++ b/ms/index.html
@@ -25,6 +25,13 @@
 			alert('The File APIs are not fully supported in this browser.');
 			}
 		</script>
+		<script src="https://cdn.jsdelivr.net/npm/d3-require@1"></script>
+		<script>
+		  const downloadSVG = async () => {
+		    crowbar = await d3.require('svg-crowbar@0.3.1/dist/main.js');
+		    crowbar.default(document.getElementsByTagName('svg')[0]);
+		  }
+		</script>
 		<script>
 			$(document).ready(function() {
 				//file variables
@@ -993,15 +1000,7 @@
 				
 				$('#svgdownload').click(function (e) {
 					setCookies();
-					var e = document.createElement('script');
-					if (window.location.protocol === 'https:') { 
-						e.setAttribute('src', 'https://raw.github.com/NYTimes/svg-crowbar/gh-pages/svg-crowbar.js'); 
-					} 
-					else { 
-						e.setAttribute('src', 'http://nytimes.github.com/svg-crowbar/svg-crowbar.js'); 
-					}
-					e.setAttribute('class', 'svg-crowbar'); 
-					document.body.appendChild(e); 
+					downloadSVG();
 				});
 				
 				$( "#rdio" ).buttonset();


### PR DESCRIPTION
The svg-crowbar library wasn't loading properly, this is a quick fix (and probably breaks old browsers).

I couldn't run this with the http/https mismatch so https://thomasballinger.github.io/rkwant.github.io/ms/index.html (master on this repo) includes this fix and a bunch of HTTP -> HTTPS fixes as well. You could take these too, but I don't think they're necessary.